### PR TITLE
add egress fqdnpolicy + allow tenant-alertmanager

### DIFF
--- a/charts/smsmanager/Chart.yaml
+++ b/charts/smsmanager/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: smsmanager
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.0
+version: 1.1.1

--- a/charts/smsmanager/templates/networkpolicy.yaml
+++ b/charts/smsmanager/templates/networkpolicy.yaml
@@ -5,17 +5,31 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}
 spec:
-  egress:
-    - {}
   ingress:
     - from:
       - podSelector:
-          matchLabels:
-            app.kubernetes.io/name: alertmanager
-            alertmanager: "monitoring-nais-prometheus"
+          matchExpressions:
+            - {key: app.kubernetes.io/name, operator: In, values: [alertmanager]}
+            - {key: alertmanager, operator: In, values: [monitoring-nais-alertmanager,monitoring-tenant-alertmanager]}
   policyTypes:
-    - Egress
     - Ingress
   podSelector:
     matchLabels: {{ include "smsmanager.selectorLabels" . | nindent 6 }}
+---
+apiVersion: networking.gke.io/v1alpha3
+kind: FQDNNetworkPolicy
+metadata:
+  name: {{ .Release.Name}}-fqdn
+spec:
+  egress:
+  - ports:
+    - port: 8080
+      protocol: TCP
+    to:
+    - fqdns:
+      - sysmanp.adeo.no
+  podSelector:
+    matchLabels: {{ include "smsmanager.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Egress
 {{- end }}


### PR DESCRIPTION
Ser du også oppdaget at vi åpnet for prometheus og ikke alertnanager. :) Tror det er greit at vi også åpner for tenant alertmanager så andre enn oss også kan bruke sms. La til utgående network policy også