### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,8 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 


### PR DESCRIPTION
Potential fix for [https://github.com/nais/smsmanager/security/code-scanning/12](https://github.com/nais/smsmanager/security/code-scanning/12)

To fix this, explicitly declare a least-privilege `permissions` block for the `test` job.

Best approach here without changing functionality:
- Edit `.github/workflows/main.yaml`
- In the `jobs.test` section, add:
  - `permissions:`
  - `contents: read`

Why this is best:
- `actions/checkout` requires `contents: read` for private repos (and is appropriate in general).
- It scopes only the previously-unscoped job (`test`) and does not alter existing permission choices in `build_and_push` or `deploy`.
- It directly addresses the CodeQL finding on the highlighted `test` job.

No imports, methods, or extra definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
